### PR TITLE
feat: add themed header and background

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import './globals.css'
+import AmbientBackground from '../components/layout/AmbientBackground'
 
 export const metadata: Metadata = {
   title: 'PudChat',
@@ -12,8 +13,11 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en">
-      <body className="antialiased">{children}</body>
+    <html lang="zh-cn" className="dark">
+      <body className="antialiased bg-slate-950 text-slate-100">
+        <AmbientBackground />
+        {children}
+      </body>
     </html>
   )
 }

--- a/apps/web/src/components/common/ThemeToggle.tsx
+++ b/apps/web/src/components/common/ThemeToggle.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Moon, Sun } from 'lucide-react'
+
+const STORAGE_KEY = 'pudchat.theme'
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState<'dark' | 'light'>('dark')
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const saved =
+      (localStorage.getItem(STORAGE_KEY) as 'dark' | 'light') || 'dark'
+    setTheme(saved)
+    document.documentElement.classList.toggle('dark', saved === 'dark')
+  }, [])
+
+  const toggle = () => {
+    const next = theme === 'dark' ? 'light' : 'dark'
+    setTheme(next)
+    document.documentElement.classList.toggle('dark', next === 'dark')
+    localStorage.setItem(STORAGE_KEY, next)
+  }
+
+  return (
+    <button
+      type="button"
+      aria-label="切换主题"
+      className="rounded-full border border-white/20 bg-white/5 p-2 text-slate-200 hover:bg-white/10 transition-colors"
+      onClick={toggle}
+    >
+      {theme === 'dark' ? (
+        <Sun className="h-4 w-4" />
+      ) : (
+        <Moon className="h-4 w-4" />
+      )}
+    </button>
+  )
+}

--- a/apps/web/src/components/layout/AmbientBackground.tsx
+++ b/apps/web/src/components/layout/AmbientBackground.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+export default function AmbientBackground() {
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none fixed inset-0 -z-10 overflow-hidden"
+    >
+      <div className="absolute -top-40 -left-40 h-96 w-96 rounded-full bg-cyan-500/20 blur-3xl motion-safe:animate-pulse" />
+      <div className="absolute -bottom-40 -right-40 h-96 w-96 rounded-full bg-indigo-500/20 blur-3xl motion-safe:animate-pulse" />
+    </div>
+  )
+}

--- a/apps/web/src/components/layout/AppShell.tsx
+++ b/apps/web/src/components/layout/AppShell.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import Sidebar from '../sidebar/Sidebar'
 import ChatView from '../chat/ChatView'
 import RightPanel from '../right/RightPanel'
+import Header from './Header'
 import { useChat } from '../../hooks/useChat'
 import {
   loadSettings,
@@ -12,7 +13,7 @@ import {
   loadLastModel,
   saveLastModel,
 } from '../../lib/storage'
-import { Menu, PanelRight, X } from 'lucide-react'
+import { X } from 'lucide-react'
 
 export default function AppShell() {
   const [settings, setSettings] = useState<Settings>(defaultSettings)
@@ -37,76 +38,75 @@ export default function AppShell() {
   const [rightOpen, setRightOpen] = useState(false)
 
   return (
-    <div className="flex h-screen">
-      {/* desktop sidebar */}
-      <div className="hidden lg:flex">
-        <Sidebar chat={chat} settings={settings} setSettings={setSettings} />
-      </div>
-      {/* mobile left drawer */}
-      {leftOpen && (
-        <>
-          <div
-            className="fixed inset-y-0 left-72 right-0 z-40 bg-black/20"
-            onClick={() => setLeftOpen(false)}
-          />
-          <div className="fixed inset-y-0 left-0 z-50 w-72 bg-background shadow-lg relative">
-            <Sidebar
-              chat={chat}
-              settings={settings}
-              setSettings={setSettings}
-            />
-            <button
-              className="absolute right-4 top-4 rounded border p-1"
-              onClick={() => setLeftOpen(false)}
-            >
-              <X className="h-5 w-5" />
-            </button>
-          </div>
-        </>
-      )}
-
-      {/* main chat */}
-      <div className="flex flex-1 flex-col">
-        {/* mobile top bar */}
-        <div className="flex items-center justify-between border-b p-2 lg:hidden">
-          <button onClick={() => setLeftOpen(true)}>
-            <Menu className="h-5 w-5" />
-          </button>
-          <div className="font-semibold">{chat.current?.title}</div>
-          <button onClick={() => setRightOpen(true)}>
-            <PanelRight className="h-5 w-5" />
-          </button>
+    <div className="flex h-screen flex-col">
+      <Header
+        settings={settings}
+        selectedModel={selectedModel}
+        setSelectedModel={setSelectedModel}
+        onOpenLeft={() => setLeftOpen(true)}
+        onOpenRight={() => setRightOpen(true)}
+      />
+      <div className="flex flex-1">
+        {/* desktop sidebar */}
+        <div className="hidden lg:flex">
+          <Sidebar chat={chat} settings={settings} setSettings={setSettings} />
         </div>
-        <ChatView
-          chat={chat}
-          settings={settings}
-          selectedModel={selectedModel}
-          setSelectedModel={setSelectedModel}
-        />
-      </div>
+        {/* mobile left drawer */}
+        {leftOpen && (
+          <>
+            <div
+              className="fixed inset-y-0 left-72 right-0 z-40 bg-black/20"
+              onClick={() => setLeftOpen(false)}
+            />
+            <div className="fixed inset-y-0 left-0 z-50 w-72 bg-background shadow-lg relative">
+              <Sidebar
+                chat={chat}
+                settings={settings}
+                setSettings={setSettings}
+              />
+              <button
+                className="absolute right-4 top-4 rounded border p-1"
+                onClick={() => setLeftOpen(false)}
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+          </>
+        )}
 
-      {/* desktop right panel */}
-      <div className="hidden lg:flex">
-        <RightPanel chat={chat} selectedModel={selectedModel} />
-      </div>
-      {/* mobile right drawer */}
-      {rightOpen && (
-        <>
-          <div
-            className="fixed inset-y-0 left-0 right-80 z-40 bg-black/20"
-            onClick={() => setRightOpen(false)}
+        {/* main chat */}
+        <div className="flex flex-1 flex-col">
+          <ChatView
+            chat={chat}
+            settings={settings}
+            selectedModel={selectedModel}
+            setSelectedModel={setSelectedModel}
           />
-          <div className="fixed inset-y-0 right-0 z-50 w-80 bg-background shadow-lg relative">
-            <RightPanel chat={chat} selectedModel={selectedModel} />
-            <button
-              className="absolute left-4 top-4 rounded border p-1"
+        </div>
+
+        {/* desktop right panel */}
+        <div className="hidden lg:flex">
+          <RightPanel chat={chat} selectedModel={selectedModel} />
+        </div>
+        {/* mobile right drawer */}
+        {rightOpen && (
+          <>
+            <div
+              className="fixed inset-y-0 left-0 right-80 z-40 bg-black/20"
               onClick={() => setRightOpen(false)}
-            >
-              <X className="h-5 w-5" />
-            </button>
-          </div>
-        </>
-      )}
+            />
+            <div className="fixed inset-y-0 right-0 z-50 w-80 bg-background shadow-lg relative">
+              <RightPanel chat={chat} selectedModel={selectedModel} />
+              <button
+                className="absolute left-4 top-4 rounded border p-1"
+                onClick={() => setRightOpen(false)}
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+          </>
+        )}
+      </div>
     </div>
   )
 }

--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import ProvidersManager from '../settings/ProvidersManager'
+import ThemeToggle from '../common/ThemeToggle'
+import { Menu, PanelRight } from 'lucide-react'
+import type { Settings } from '../../lib/storage'
+
+export default function Header({
+  settings,
+  selectedModel,
+  setSelectedModel,
+  onOpenLeft,
+  onOpenRight,
+}: {
+  settings: Settings
+  selectedModel: string
+  setSelectedModel: (m: string) => void
+  onOpenLeft?: () => void
+  onOpenRight?: () => void
+}) {
+  return (
+    <header className="sticky top-0 z-20 flex items-center justify-between border-b border-white/10 bg-slate-900/40 px-4 py-2 backdrop-blur">
+      <div className="flex items-center space-x-2">
+        {onOpenLeft && (
+          <button
+            className="lg:hidden"
+            onClick={onOpenLeft}
+            aria-label="展开侧栏"
+          >
+            <Menu className="h-5 w-5" />
+          </button>
+        )}
+        <div className="h-6 w-6 rounded-xl bg-gradient-to-br from-cyan-400 to-indigo-600" />
+        <h1 className="text-sm sm:text-base font-semibold text-slate-100">
+          PudChat · 角色扮演
+        </h1>
+        <span className="rounded-full bg-white/10 px-2 py-0.5 text-xs text-slate-200">
+          预览
+        </span>
+      </div>
+      <div className="flex items-center space-x-2">
+        {onOpenRight && (
+          <button
+            className="lg:hidden"
+            onClick={onOpenRight}
+            aria-label="展开设置"
+          >
+            <PanelRight className="h-5 w-5" />
+          </button>
+        )}
+        <ProvidersManager />
+        {settings.models.length > 0 ? (
+          <select
+            className="max-w-[12rem] truncate rounded-xl border border-white/20 bg-white/5 px-2 py-1 text-sm text-slate-100"
+            value={selectedModel}
+            onChange={(e) => setSelectedModel(e.target.value)}
+          >
+            {settings.models.map((m, i) => (
+              <option key={i} value={m.name} className="text-black">
+                {m.name}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <select
+            className="max-w-[12rem] rounded-xl border border-white/20 bg-white/5 px-2 py-1 text-sm text-slate-400"
+            disabled
+          >
+            <option>无模型</option>
+          </select>
+        )}
+        <ThemeToggle />
+        <button
+          className="rounded-xl border border-white/20 bg-white/5 px-3 py-1 text-sm text-slate-200 opacity-50 cursor-not-allowed"
+          aria-label="账户"
+          disabled
+        >
+          账户
+        </button>
+      </div>
+    </header>
+  )
+}

--- a/apps/web/src/components/settings/ProvidersManager.tsx
+++ b/apps/web/src/components/settings/ProvidersManager.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useState } from 'react'
+import * as Dialog from '@radix-ui/react-dialog'
+import { X } from 'lucide-react'
+
+export default function ProvidersManager() {
+  const [open, setOpen] = useState(false)
+  return (
+    <Dialog.Root open={open} onOpenChange={setOpen}>
+      <Dialog.Trigger asChild>
+        <button
+          type="button"
+          className="rounded-xl border border-white/20 bg-white/5 px-3 py-1 text-sm text-slate-200 transition-colors hover:bg-white/10"
+        >
+          模型管理
+        </button>
+      </Dialog.Trigger>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-black/40 backdrop-blur-sm" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-[90vw] max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-white/10 bg-slate-900/80 p-6 text-slate-200 backdrop-blur-xl focus:outline-none">
+          <Dialog.Title className="text-lg font-semibold">
+            模型管理
+          </Dialog.Title>
+          <p className="mt-2 text-sm text-slate-400">功能开发中，敬请期待。</p>
+          <button
+            type="button"
+            className="absolute right-4 top-4 rounded p-1 border border-white/20 hover:bg-white/10"
+            onClick={() => setOpen(false)}
+            aria-label="关闭"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}


### PR DESCRIPTION
## Summary
- add ambient radial background and default dark theme
- introduce sticky header with model controls and placeholder provider modal
- implement theme toggle with localStorage persistence

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68aafcdaeda0832a8006e0c916093337